### PR TITLE
Fix #9: skip OpenAI analysis when deploy_results is false

### DIFF
--- a/.github/workflows/report/action.yaml
+++ b/.github/workflows/report/action.yaml
@@ -147,7 +147,9 @@ runs:
           gcreport="--no-gc-report"
         fi 
 
-        if [ "${{ inputs.open-ai-request }}" == "true" ]; then
+        # OpenAI analysis is only useful when results are deployed to gh-pages.
+        # Avoid unnecessary API calls when deploy_results is false.
+        if [ "${{ inputs.open-ai-request }}" == "true" ] && [ "${{ inputs.deploy_results }}" == "true" ]; then
           openai_request="--open-ai-request"
         else
           openai_request="--no-open-ai-request"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This workflow executes Gradle tasks across two specified variants (branches) wit
     - **Options (keys in the JSON string)**:
       - `deploy_results`: Enable or disable deployment of results to https://cdsap.github.io/Telltale/ (`'true'` or `'false'`).
       - `experiment_title`: Title for the experiment (string).
-      - `open_ai_request`: Enable or disable OpenAI request (`'true'` or `'false'`).
+      - `open_ai_request`: Enable or disable OpenAI request (`'true'` or `'false'`). Note: OpenAI analysis only runs when `deploy_results` is also `'true'`.
       - `report_enabled`: Enable or disable report generation (`'true'` or `'false'`).
       - `tasktype_report`: Include task type reports (`'true'` or `'false'`).
       - `taskpath_report`: Include task path reports (`'true'` or `'false'`).

--- a/docs/actions-inputs.md
+++ b/docs/actions-inputs.md
@@ -151,7 +151,7 @@ This section describes the inputs for the reusable `report/action.yaml` workflow
   - Description: A custom title for the experiment report.
   - Required: `false`.
 - **`open-ai-request`**:
-  - Description: Enable or disable requesting analysis from OpenAI.
+  - Description: Enable or disable requesting analysis from OpenAI. Analysis is only requested when `deploy_results` is also `'true'`.
   - Required: `true`.
   - Default: `false`.
   - Type: String (`'true'` or `'false'`).


### PR DESCRIPTION
This PR fixes #9 by preventing OpenAI analysis requests when results are not being deployed.

Changes:
- In .github/workflows/report/action.yaml, OpenAI analysis is now enabled only when both:
  - open-ai-request == 'true'
  - deploy_results == 'true'
- Updated docs in README.md and docs/actions-inputs.md to clarify this behavior.

Why:
- The report action was still requesting OpenAI analysis even when deploy_results was false, which can trigger unnecessary API calls.

Closes #9
