### PR TITLE
feat: add reusable Gradle configuration cache mode

### DIFF
--- a/.github/workflows/experiment-with-gradle-profiler.yaml
+++ b/.github/workflows/experiment-with-gradle-profiler.yaml
@@ -40,8 +40,11 @@ on:
           - 'off'
           - 'disabled'
           - 'on'
+          - 'on-no-entry'
           - 'warn'
+          - 'warn-no-entry'
           - 'read-only'
+          - 'read-only-no-entry'
       project_isolation:
         description: "Gradle Isolated Projects behavior"
         type: choice
@@ -50,7 +53,9 @@ on:
         options:
           - 'off'
           - 'on'
+          - 'on-no-entry'
           - 'diagnostics'
+          - 'diagnostics-no-entry'
       os_args:
         description: "Operating system configurations for variants"
         type: string

--- a/.github/workflows/experiment-with-gradle-profiler.yaml
+++ b/.github/workflows/experiment-with-gradle-profiler.yaml
@@ -31,6 +31,15 @@ on:
         required: false
         type: boolean
         default: true
+      configuration_cache:
+        description: "Gradle configuration cache behavior"
+        type: choice
+        required: false
+        default: 'off'
+        options:
+          - 'off'
+          - 'on'
+          - 'warn'
       os_args:
         description: "Operating system configurations for variants"
         type: string
@@ -91,6 +100,7 @@ jobs:
           experiment-id: "profiler-${{ github.repository_owner }}-${{ github.run_number }}"
           variant: ${{ matrix.config.variant }}
           class: ${{ github.event.inputs.class }}
+          configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           cache-url: ${{ secrets.CI_URL_CACHE_NODE }}
           warmups: 1
           clean-between-iterations: ${{ github.event.inputs.clean_between_iterations }}

--- a/.github/workflows/experiment-with-gradle-profiler.yaml
+++ b/.github/workflows/experiment-with-gradle-profiler.yaml
@@ -41,6 +41,7 @@ on:
           - 'disabled'
           - 'on'
           - 'warn'
+          - 'read-only'
       project_isolation:
         description: "Gradle Isolated Projects behavior"
         type: choice

--- a/.github/workflows/experiment-with-gradle-profiler.yaml
+++ b/.github/workflows/experiment-with-gradle-profiler.yaml
@@ -40,6 +40,15 @@ on:
           - 'off'
           - 'on'
           - 'warn'
+      project_isolation:
+        description: "Gradle Isolated Projects behavior"
+        type: choice
+        required: false
+        default: 'off'
+        options:
+          - 'off'
+          - 'on'
+          - 'diagnostics'
       os_args:
         description: "Operating system configurations for variants"
         type: string
@@ -101,6 +110,7 @@ jobs:
           variant: ${{ matrix.config.variant }}
           class: ${{ github.event.inputs.class }}
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
+          project-isolation: "${{ github.event.inputs.project_isolation }}"
           cache-url: ${{ secrets.CI_URL_CACHE_NODE }}
           warmups: 1
           clean-between-iterations: ${{ github.event.inputs.clean_between_iterations }}

--- a/.github/workflows/experiment-with-gradle-profiler.yaml
+++ b/.github/workflows/experiment-with-gradle-profiler.yaml
@@ -38,6 +38,7 @@ on:
         default: 'off'
         options:
           - 'off'
+          - 'disabled'
           - 'on'
           - 'warn'
       project_isolation:

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -50,6 +50,15 @@ on:
           - 'off'
           - 'on'
           - 'warn'
+      project_isolation:
+        description: "Gradle Isolated Projects behavior"
+        type: choice
+        required: true
+        default: 'off'
+        options:
+          - 'off'
+          - 'on'
+          - 'diagnostics'
       configuration_cache_included_builds:
         description: "Comma-separated included build paths whose build outputs should be saved with the configuration cache"
         required: false
@@ -126,6 +135,7 @@ jobs:
           task: "${{ github.event.inputs.task }}"
           mode: "${{ github.event.inputs.mode }}"
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
+          project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -166,6 +176,7 @@ jobs:
           task: "${{ github.event.inputs.task }}"
           mode: "${{ github.event.inputs.mode }}"
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
+          project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -205,6 +216,7 @@ jobs:
           task: "${{ github.event.inputs.task }}"
           mode: "${{ github.event.inputs.mode }}"
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
+          project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -48,6 +48,7 @@ on:
         default: 'off'
         options:
           - 'off'
+          - 'disabled'
           - 'on'
           - 'warn'
       project_isolation:

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -41,6 +41,15 @@ on:
           - 'remote task cache - transforms cache'
           - 'remote task cache + dependencies cache - transforms cache'
           - 'dependencies cache - javaCompile cache'
+      configuration_cache:
+        description: "Gradle configuration cache behavior"
+        type: choice
+        required: true
+        default: 'off'
+        options:
+          - 'off'
+          - 'on'
+          - 'warn'
       os_args:
         description: "Operating system configurations for variants"
         type: string
@@ -112,6 +121,8 @@ jobs:
           cache-exclude-script: "${{ env.cache_exclude_content }}"
           task: "${{ github.event.inputs.task }}"
           mode: "${{ github.event.inputs.mode }}"
+          configuration-cache: "${{ github.event.inputs.configuration_cache }}"
+          configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           experiment-id: "${{ github.run_number }}"
           variant: ${{ matrix.config.variant }}
           api-key: ${{ secrets.DV_ACCESS_KEY }}
@@ -148,6 +159,8 @@ jobs:
         with:
           task: "${{ github.event.inputs.task }}"
           mode: "${{ github.event.inputs.mode }}"
+          configuration-cache: "${{ github.event.inputs.configuration_cache }}"
+          configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           execution-number: ${{ github.run_number }}
           variant: ${{ matrix.config.variant }}
@@ -183,6 +196,8 @@ jobs:
         with:
           task: "${{ github.event.inputs.task }}"
           mode: "${{ github.event.inputs.mode }}"
+          configuration-cache: "${{ github.event.inputs.configuration_cache }}"
+          configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           execution-number: ${{ github.run_number }}
           variant: ${{ matrix.config.variant }}

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -51,6 +51,7 @@ on:
           - 'disabled'
           - 'on'
           - 'warn'
+          - 'read-only'
       project_isolation:
         description: "Gradle Isolated Projects behavior"
         type: choice

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -50,6 +50,10 @@ on:
           - 'off'
           - 'on'
           - 'warn'
+      configuration_cache_included_builds:
+        description: "Comma-separated included build paths whose build outputs should be saved with the configuration cache"
+        required: false
+        default: "buildSrc,build-logic"
       os_args:
         description: "Operating system configurations for variants"
         type: string
@@ -123,6 +127,7 @@ jobs:
           mode: "${{ github.event.inputs.mode }}"
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
+          configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           experiment-id: "${{ github.run_number }}"
           variant: ${{ matrix.config.variant }}
           api-key: ${{ secrets.DV_ACCESS_KEY }}
@@ -161,6 +166,7 @@ jobs:
           mode: "${{ github.event.inputs.mode }}"
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
+          configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           execution-number: ${{ github.run_number }}
           variant: ${{ matrix.config.variant }}
@@ -198,6 +204,7 @@ jobs:
           mode: "${{ github.event.inputs.mode }}"
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
+          configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           execution-number: ${{ github.run_number }}
           variant: ${{ matrix.config.variant }}

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -53,7 +53,7 @@ on:
       configuration_cache_included_builds:
         description: "Comma-separated included build paths whose build outputs should be saved with the configuration cache"
         required: false
-        default: "buildSrc,build-logic"
+        default: "buildSrc,build-logic,build-logic/*"
       os_args:
         description: "Operating system configurations for variants"
         type: string

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -128,7 +128,7 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
-          experiment-id: "${{ github.run_number }}"
+          experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           variant: ${{ matrix.config.variant }}
           api-key: ${{ secrets.DV_ACCESS_KEY }}
           repository: ${{ github.event.inputs.repository }}

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -128,6 +128,7 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           variant: ${{ matrix.config.variant }}
           api-key: ${{ secrets.DV_ACCESS_KEY }}
@@ -167,6 +168,7 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           execution-number: ${{ github.repository_owner }}-${{ github.run_number }}
           variant: ${{ matrix.config.variant }}
@@ -205,6 +207,7 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
           execution-number: ${{ github.repository_owner }}-${{ github.run_number }}
           variant: ${{ matrix.config.variant }}

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -168,7 +168,7 @@ jobs:
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
-          execution-number: ${{ github.run_number }}
+          execution-number: ${{ github.repository_owner }}-${{ github.run_number }}
           variant: ${{ matrix.config.variant }}
           api-key: ${{ secrets.DV_ACCESS_KEY }}
           cache-excludes: ${{ steps.seed.outputs.cache-excludes }}
@@ -206,7 +206,7 @@ jobs:
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
-          execution-number: ${{ github.run_number }}
+          execution-number: ${{ github.repository_owner }}-${{ github.run_number }}
           variant: ${{ matrix.config.variant }}
           api-key: ${{ secrets.DV_ACCESS_KEY }}
           repository: ${{ github.event.inputs.repository }}

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -50,8 +50,11 @@ on:
           - 'off'
           - 'disabled'
           - 'on'
+          - 'on-no-entry'
           - 'warn'
+          - 'warn-no-entry'
           - 'read-only'
+          - 'read-only-no-entry'
       project_isolation:
         description: "Gradle Isolated Projects behavior"
         type: choice
@@ -60,19 +63,13 @@ on:
         options:
           - 'off'
           - 'on'
+          - 'on-no-entry'
           - 'diagnostics'
+          - 'diagnostics-no-entry'
       configuration_cache_included_builds:
         description: "Comma-separated included build paths whose build outputs should be saved with the configuration cache"
         required: false
         default: "buildSrc,build-logic,build-logic/*"
-      configuration_cache_entry:
-        description: "Whether to save and restore the explicit configuration cache entry bundle"
-        type: choice
-        required: true
-        default: 'restore'
-        options:
-          - 'restore'
-          - 'skip'
       os_args:
         description: "Operating system configurations for variants"
         type: string
@@ -147,7 +144,6 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
-          configuration-cache-entry: "${{ github.event.inputs.configuration_cache_entry }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
@@ -189,7 +185,6 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
-          configuration-cache-entry: "${{ github.event.inputs.configuration_cache_entry }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
@@ -230,7 +225,6 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
-          configuration-cache-entry: "${{ github.event.inputs.configuration_cache_entry }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"

--- a/.github/workflows/experiment.yaml
+++ b/.github/workflows/experiment.yaml
@@ -63,6 +63,14 @@ on:
         description: "Comma-separated included build paths whose build outputs should be saved with the configuration cache"
         required: false
         default: "buildSrc,build-logic,build-logic/*"
+      configuration_cache_entry:
+        description: "Whether to save and restore the explicit configuration cache entry bundle"
+        type: choice
+        required: true
+        default: 'restore'
+        options:
+          - 'restore'
+          - 'skip'
       os_args:
         description: "Operating system configurations for variants"
         type: string
@@ -137,6 +145,7 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
+          configuration-cache-entry: "${{ github.event.inputs.configuration_cache_entry }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
@@ -178,6 +187,7 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
+          configuration-cache-entry: "${{ github.event.inputs.configuration_cache_entry }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"
@@ -218,6 +228,7 @@ jobs:
           configuration-cache: "${{ github.event.inputs.configuration_cache }}"
           project-isolation: "${{ github.event.inputs.project_isolation }}"
           configuration-cache-key: "configuration-cache-${{ runner.os }}-${{ github.repository_owner }}-${{ github.run_number }}-${{ matrix.config.index }}"
+          configuration-cache-entry: "${{ github.event.inputs.configuration_cache_entry }}"
           configuration-cache-included-builds: "${{ github.event.inputs.configuration_cache_included_builds }}"
           gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           experiment-id: "${{ github.repository_owner }}-${{ github.run_number }}"

--- a/.github/workflows/runner-gradle-profiler/action.yaml
+++ b/.github/workflows/runner-gradle-profiler/action.yaml
@@ -46,6 +46,10 @@ inputs:
     description: 'Gradle configuration cache behavior: off, on, or warn.'
     required: false
     default: 'off'
+  project-isolation:
+    description: 'Gradle Isolated Projects behavior: off, on, or diagnostics.'
+    required: false
+    default: 'off'
   cache-url:
     description: 'URL for the cache node, if applicable'
     required: true
@@ -110,8 +114,27 @@ runs:
             ;;
         esac
 
+        case "${{ inputs.project-isolation }}" in
+          "off"|"")
+            PROJECT_ISOLATION_ARGS=()
+            ;;
+          "on")
+            PROJECT_ISOLATION_ARGS=("-Dorg.gradle.unsafe.isolated-projects=true")
+            ;;
+          "diagnostics")
+            PROJECT_ISOLATION_ARGS=("-Dorg.gradle.unsafe.isolated-projects=true" "-Dorg.gradle.unsafe.isolated-projects.diagnostics=true")
+            ;;
+          *)
+            echo "Unknown project isolation option: ${{ inputs.project-isolation }}"
+            exit 1
+            ;;
+        esac
+
         GRADLE_ARGS="[\"$EXTRA_ARG\""
         for ARG in "${CONFIGURATION_CACHE_ARGS[@]}"; do
+          GRADLE_ARGS="$GRADLE_ARGS, \"$ARG\""
+        done
+        for ARG in "${PROJECT_ISOLATION_ARGS[@]}"; do
           GRADLE_ARGS="$GRADLE_ARGS, \"$ARG\""
         done
         GRADLE_ARGS="$GRADLE_ARGS, \"-Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }}\", \"-Dscan.tag.experiment\", \"-Dscan.tag.${{ inputs.experiment-id }}\"]"

--- a/.github/workflows/runner-gradle-profiler/action.yaml
+++ b/.github/workflows/runner-gradle-profiler/action.yaml
@@ -43,7 +43,7 @@ inputs:
     description: 'Extra arguments to pass to the Gradle command'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, disabled, on, or warn.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, warn, or read-only.'
     required: false
     default: 'off'
   project-isolation:
@@ -110,6 +110,9 @@ runs:
             ;;
           "warn")
             CONFIGURATION_CACHE_ARGS=("--configuration-cache" "--configuration-cache-problems=warn")
+            ;;
+          "read-only")
+            CONFIGURATION_CACHE_ARGS=("--configuration-cache" "-Dorg.gradle.configuration-cache.read-only=true")
             ;;
           *)
             echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"

--- a/.github/workflows/runner-gradle-profiler/action.yaml
+++ b/.github/workflows/runner-gradle-profiler/action.yaml
@@ -43,11 +43,11 @@ inputs:
     description: 'Extra arguments to pass to the Gradle command'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, disabled, on, warn, or read-only.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, on-no-entry, warn, warn-no-entry, read-only, or read-only-no-entry.'
     required: false
     default: 'off'
   project-isolation:
-    description: 'Gradle Isolated Projects behavior: off, on, or diagnostics.'
+    description: 'Gradle Isolated Projects behavior: off, on, on-no-entry, diagnostics, or diagnostics-no-entry.'
     required: false
     default: 'off'
   cache-url:
@@ -111,13 +111,13 @@ runs:
           "disabled")
             CONFIGURATION_CACHE_ARGS=("--no-configuration-cache" "-Dorg.gradle.unsafe.isolated-projects=false")
             ;;
-          "on")
+          "on"|"on-no-entry")
             CONFIGURATION_CACHE_ARGS=("--configuration-cache")
             ;;
-          "warn")
+          "warn"|"warn-no-entry")
             CONFIGURATION_CACHE_ARGS=("--configuration-cache" "--configuration-cache-problems=warn")
             ;;
-          "read-only")
+          "read-only"|"read-only-no-entry")
             CONFIGURATION_CACHE_ARGS=("--configuration-cache" "-Dorg.gradle.configuration-cache.read-only=true")
             ;;
           *)
@@ -130,10 +130,10 @@ runs:
           "off"|"")
             PROJECT_ISOLATION_ARGS=()
             ;;
-          "on")
+          "on"|"on-no-entry")
             PROJECT_ISOLATION_ARGS=("--isolated-projects")
             ;;
-          "diagnostics")
+          "diagnostics"|"diagnostics-no-entry")
             PROJECT_ISOLATION_ARGS=("--isolated-projects" "-Dorg.gradle.unsafe.isolated-projects.diagnostics=true")
             ;;
           *)

--- a/.github/workflows/runner-gradle-profiler/action.yaml
+++ b/.github/workflows/runner-gradle-profiler/action.yaml
@@ -119,10 +119,10 @@ runs:
             PROJECT_ISOLATION_ARGS=()
             ;;
           "on")
-            PROJECT_ISOLATION_ARGS=("-Dorg.gradle.unsafe.isolated-projects=true")
+            PROJECT_ISOLATION_ARGS=("--isolated-projects")
             ;;
           "diagnostics")
-            PROJECT_ISOLATION_ARGS=("-Dorg.gradle.unsafe.isolated-projects=true" "-Dorg.gradle.unsafe.isolated-projects.diagnostics=true")
+            PROJECT_ISOLATION_ARGS=("--isolated-projects" "-Dorg.gradle.unsafe.isolated-projects.diagnostics=true")
             ;;
           *)
             echo "Unknown project isolation option: ${{ inputs.project-isolation }}"

--- a/.github/workflows/runner-gradle-profiler/action.yaml
+++ b/.github/workflows/runner-gradle-profiler/action.yaml
@@ -43,7 +43,7 @@ inputs:
     description: 'Extra arguments to pass to the Gradle command'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, on, or warn.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, or warn.'
     required: false
     default: 'off'
   project-isolation:
@@ -101,6 +101,9 @@ runs:
         case "${{ inputs.configuration-cache }}" in
           "off"|"")
             CONFIGURATION_CACHE_ARGS=()
+            ;;
+          "disabled")
+            CONFIGURATION_CACHE_ARGS=("--no-configuration-cache")
             ;;
           "on")
             CONFIGURATION_CACHE_ARGS=("--configuration-cache")

--- a/.github/workflows/runner-gradle-profiler/action.yaml
+++ b/.github/workflows/runner-gradle-profiler/action.yaml
@@ -98,12 +98,18 @@ runs:
           EXTRA_ARG="${{ inputs.extra-args }}"
         fi
 
+        if [ "${{ inputs.configuration-cache }}" = "disabled" ] && [ "${{ inputs.project-isolation }}" != "off" ] && [ -n "${{ inputs.project-isolation }}" ]; then
+          echo "configuration-cache=disabled cannot be combined with project-isolation=${{ inputs.project-isolation }}."
+          echo "Gradle requires configuration cache when Isolated Projects is enabled."
+          exit 1
+        fi
+
         case "${{ inputs.configuration-cache }}" in
           "off"|"")
             CONFIGURATION_CACHE_ARGS=()
             ;;
           "disabled")
-            CONFIGURATION_CACHE_ARGS=("--no-configuration-cache")
+            CONFIGURATION_CACHE_ARGS=("--no-configuration-cache" "-Dorg.gradle.unsafe.isolated-projects=false")
             ;;
           "on")
             CONFIGURATION_CACHE_ARGS=("--configuration-cache")

--- a/.github/workflows/runner-gradle-profiler/action.yaml
+++ b/.github/workflows/runner-gradle-profiler/action.yaml
@@ -42,6 +42,10 @@ inputs:
   extra-args:
     description: 'Extra arguments to pass to the Gradle command'
     required: true
+  configuration-cache:
+    description: 'Gradle configuration cache behavior: off, on, or warn.'
+    required: false
+    default: 'off'
   cache-url:
     description: 'URL for the cache node, if applicable'
     required: true
@@ -90,6 +94,28 @@ runs:
           EXTRA_ARG="${{ inputs.extra-args }}"
         fi
 
+        case "${{ inputs.configuration-cache }}" in
+          "off"|"")
+            CONFIGURATION_CACHE_ARGS=()
+            ;;
+          "on")
+            CONFIGURATION_CACHE_ARGS=("--configuration-cache")
+            ;;
+          "warn")
+            CONFIGURATION_CACHE_ARGS=("--configuration-cache" "--configuration-cache-problems=warn")
+            ;;
+          *)
+            echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
+            exit 1
+            ;;
+        esac
+
+        GRADLE_ARGS="[\"$EXTRA_ARG\""
+        for ARG in "${CONFIGURATION_CACHE_ARGS[@]}"; do
+          GRADLE_ARGS="$GRADLE_ARGS, \"$ARG\""
+        done
+        GRADLE_ARGS="$GRADLE_ARGS, \"-Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }}\", \"-Dscan.tag.experiment\", \"-Dscan.tag.${{ inputs.experiment-id }}\"]"
+
         # Gradle Profiler: cleanup-tasks run between iterations; [] = incremental re-runs
         if [ "${{ inputs.clean-between-iterations }}" = "true" ]; then
           CLEANUP_TASKS='["clean"]'
@@ -103,7 +129,7 @@ runs:
             title = \"assemble\"
             tasks = [\"${{ inputs.task }}\"]
             cleanup-tasks = $CLEANUP_TASKS
-            gradle-args = [\"$EXTRA_ARG\", \"-Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }}\", \"-Dscan.tag.experiment\", \"-Dscan.tag.${{ inputs.experiment-id }}\"]
+            gradle-args = $GRADLE_ARGS
           }" > scenario
         else
           echo "assemble {
@@ -111,7 +137,7 @@ runs:
             tasks = [\"${{ inputs.task }}\"]
             cleanup-tasks = $CLEANUP_TASKS
             apply-abi-change-to = [${{ inputs.class }}]
-            gradle-args = [\"$EXTRA_ARG\", \"-Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }}\", \"-Dscan.tag.experiment\", \"-Dscan.tag.${{ inputs.experiment-id }}\"]
+            gradle-args = $GRADLE_ARGS
           }" > scenario
         fi 
 

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -192,6 +192,7 @@ runs:
       shell: bash
       env:
         DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}
+        GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Prime Configuration Cache

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -163,6 +163,15 @@ runs:
         remote_monitoring: 'true'
         export_to_bigquery: 'true'
 
+    - name: Validate Gradle Feature Combination
+      run: |
+        if [ "${{ inputs.configuration-cache }}" = "disabled" ] && [ "${{ inputs.project-isolation }}" != "off" ] && [ -n "${{ inputs.project-isolation }}" ]; then
+          echo "configuration-cache=disabled cannot be combined with project-isolation=${{ inputs.project-isolation }}."
+          echo "Gradle requires configuration cache when Isolated Projects is enabled."
+          exit 1
+        fi
+      shell: bash
+
     - name: Set Configuration Cache Arguments
       id: configuration-cache-args
       run: |
@@ -171,7 +180,7 @@ runs:
             echo "args=" >> "$GITHUB_OUTPUT"
             ;;
           "disabled")
-            echo "args=--no-configuration-cache" >> "$GITHUB_OUTPUT"
+            echo "args=--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false" >> "$GITHUB_OUTPUT"
             ;;
           "on")
             echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -32,20 +32,16 @@ inputs:
     description: 'Mode of execution relative to caching.'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, disabled, on, warn, or read-only.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, on-no-entry, warn, warn-no-entry, read-only, or read-only-no-entry.'
     required: false
     default: 'off'
   project-isolation:
-    description: 'Gradle Isolated Projects behavior: off, on, or diagnostics.'
+    description: 'Gradle Isolated Projects behavior: off, on, on-no-entry, diagnostics, or diagnostics-no-entry.'
     required: false
     default: 'off'
   configuration-cache-key:
     description: 'Cache key used to save the project configuration cache.'
     required: false
-  configuration-cache-entry:
-    description: 'Whether to save the seeded configuration cache entry bundle: restore or skip.'
-    required: false
-    default: 'restore'
   configuration-cache-included-builds:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
@@ -147,8 +143,57 @@ runs:
       env:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.experiment-id }}-${{ inputs.variant }}
 
+    - name: Set Gradle Feature State
+      id: gradle-feature-state
+      run: |
+        feature_enabled=false
+        entry_mode=skip
+        no_entry=false
+
+        case "${{ inputs.configuration-cache }}" in
+          "off"|"disabled"|"")
+            ;;
+          "on"|"warn"|"read-only")
+            feature_enabled=true
+            entry_mode=restore
+            ;;
+          "on-no-entry"|"warn-no-entry"|"read-only-no-entry")
+            feature_enabled=true
+            no_entry=true
+            ;;
+          *)
+            echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
+            exit 1
+            ;;
+        esac
+
+        case "${{ inputs.project-isolation }}" in
+          "off"|"")
+            ;;
+          "on"|"diagnostics")
+            feature_enabled=true
+            entry_mode=restore
+            ;;
+          "on-no-entry"|"diagnostics-no-entry")
+            feature_enabled=true
+            no_entry=true
+            ;;
+          *)
+            echo "Unknown project isolation option: ${{ inputs.project-isolation }}"
+            exit 1
+            ;;
+        esac
+
+        if [ "$no_entry" = true ]; then
+          entry_mode=skip
+        fi
+
+        echo "feature_enabled=$feature_enabled" >> "$GITHUB_OUTPUT"
+        echo "entry_mode=$entry_mode" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off'
+      if: steps.gradle-feature-state.outputs.feature_enabled == 'true'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
           echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
@@ -172,67 +217,9 @@ runs:
         fi
       shell: bash
 
-    - name: Set Configuration Cache Arguments
-      id: configuration-cache-args
-      run: |
-        case "${{ inputs.configuration-cache }}" in
-          "off"|"")
-            echo "args=" >> "$GITHUB_OUTPUT"
-            ;;
-          "disabled")
-            echo "args=--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false" >> "$GITHUB_OUTPUT"
-            ;;
-          "on")
-            echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"
-            ;;
-          "warn")
-            echo "args=--configuration-cache --configuration-cache-problems=warn" >> "$GITHUB_OUTPUT"
-            ;;
-          "read-only")
-            echo "args=--configuration-cache -Dorg.gradle.configuration-cache.read-only=true" >> "$GITHUB_OUTPUT"
-            ;;
-          *)
-            echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
-            exit 1
-            ;;
-        esac
-      shell: bash
-
-    - name: Set Project Isolation Arguments
-      id: project-isolation-args
-      run: |
-        case "${{ inputs.project-isolation }}" in
-          "off"|"")
-            echo "args=" >> "$GITHUB_OUTPUT"
-            ;;
-          "on")
-            echo "args=--isolated-projects" >> "$GITHUB_OUTPUT"
-            ;;
-          "diagnostics")
-            echo "args=--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
-            ;;
-          *)
-            echo "Unknown project isolation option: ${{ inputs.project-isolation }}"
-            exit 1
-            ;;
-        esac
-      shell: bash
-
-    - name: Validate Configuration Cache Entry Mode
-      run: |
-        case "${{ inputs.configuration-cache-entry }}" in
-          "restore"|"skip"|"")
-            ;;
-          *)
-            echo "Unknown configuration cache entry option: ${{ inputs.configuration-cache-entry }}"
-            exit 1
-            ;;
-        esac
-      shell: bash
-
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: steps.gradle-feature-state.outputs.entry_mode == 'restore' && steps.gradle-feature-state.outputs.feature_enabled == 'true' && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -267,6 +254,52 @@ runs:
         } >> "$GITHUB_OUTPUT"
       shell: bash
 
+    - name: Set Configuration Cache Arguments
+      id: configuration-cache-args
+      run: |
+        case "${{ inputs.configuration-cache }}" in
+          "off"|"")
+            echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "disabled")
+            echo "args=--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false" >> "$GITHUB_OUTPUT"
+            ;;
+          "on"|"on-no-entry")
+            echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"
+            ;;
+          "warn"|"warn-no-entry")
+            echo "args=--configuration-cache --configuration-cache-problems=warn" >> "$GITHUB_OUTPUT"
+            ;;
+          "read-only"|"read-only-no-entry")
+            echo "args=--configuration-cache -Dorg.gradle.configuration-cache.read-only=true" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
+    - name: Set Project Isolation Arguments
+      id: project-isolation-args
+      run: |
+        case "${{ inputs.project-isolation }}" in
+          "off"|"")
+            echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "on"|"on-no-entry")
+            echo "args=--isolated-projects" >> "$GITHUB_OUTPUT"
+            ;;
+          "diagnostics"|"diagnostics-no-entry")
+            echo "args=--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "Unknown project isolation option: ${{ inputs.project-isolation }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Execute Gradle Build
       id: gradle-build
       run: |
@@ -284,7 +317,7 @@ runs:
 
     - name: Prime Configuration Cache
       id: prime-configuration-cache
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off')
+      if: steps.gradle-feature-state.outputs.entry_mode == 'restore' && steps.gradle-feature-state.outputs.feature_enabled == 'true'
       run: |
         ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} ${{ steps.project-isolation-args.outputs.args }} \
           -Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }} \
@@ -299,7 +332,7 @@ runs:
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Save Configuration Cache
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: steps.gradle-feature-state.outputs.entry_mode == 'restore' && steps.gradle-feature-state.outputs.feature_enabled == 'true' && inputs.configuration-cache-key != ''
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -31,6 +31,13 @@ inputs:
   mode:
     description: 'Mode of execution relative to caching.'
     required: true
+  configuration-cache:
+    description: 'Gradle configuration cache behavior: off, on, or warn.'
+    required: false
+    default: 'off'
+  configuration-cache-key:
+    description: 'Cache key used to save the project configuration cache.'
+    required: false
   extra-args:
     description: 'Extra arguments to pass to the Gradle command.'
     required: true
@@ -130,10 +137,30 @@ runs:
         remote_monitoring: 'true'          
         export_to_bigquery: 'true'
 
+    - name: Set Configuration Cache Arguments
+      id: configuration-cache-args
+      run: |
+        case "${{ inputs.configuration-cache }}" in
+          "off"|"")
+            echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "on")
+            echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"
+            ;;
+          "warn")
+            echo "args=--configuration-cache --configuration-cache-problems=warn" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Execute Gradle Build
       id: gradle-build
       run: |
-        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} \
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} \
           -Dscan.tag.seed_${{ inputs.variant-prefix }}${{ inputs.variant }} \
           -Dscan.tag.seed-"${{ inputs.mode }}" \
           -Dscan.tag.seed \
@@ -142,6 +169,13 @@ runs:
       env:
         DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
+
+    - name: Save Configuration Cache
+      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      uses: actions/cache/save@v4
+      with:
+        path: .gradle/configuration-cache
+        key: ${{ inputs.configuration-cache-key }}
 
     - name: Finalize Step
       uses: actions/checkout@v4

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -136,6 +136,14 @@ runs:
       env:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.experiment-id }}-${{ inputs.variant }}
 
+    - name: Disable Gradle Action Init Scripts for Configuration Cache
+      if: inputs.configuration-cache != 'off'
+      run: |
+        if [ -n "${GRADLE_USER_HOME:-}" ] && [ -d "$GRADLE_USER_HOME/init.d" ]; then
+          find "$GRADLE_USER_HOME/init.d" -maxdepth 1 -type f -name 'gradle-actions*.init.gradle' -delete
+        fi
+      shell: bash
+
     - uses: cdsap/build-process-watcher@v0.6.2
       with:
         remote_monitoring: 'true'          

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -41,7 +41,7 @@ inputs:
   configuration-cache-included-builds:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
-    default: 'buildSrc,build-logic'
+    default: 'buildSrc,build-logic,build-logic/*'
   extra-args:
     description: 'Extra arguments to pass to the Gradle command.'
     required: true

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -32,7 +32,7 @@ inputs:
     description: 'Mode of execution relative to caching.'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, disabled, on, or warn.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, warn, or read-only.'
     required: false
     default: 'off'
   project-isolation:
@@ -148,7 +148,7 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.experiment-id }}-${{ inputs.variant }}
 
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off'
+      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
           echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
@@ -178,6 +178,9 @@ runs:
             ;;
           "warn")
             echo "args=--configuration-cache --configuration-cache-problems=warn" >> "$GITHUB_OUTPUT"
+            ;;
+          "read-only")
+            echo "args=--configuration-cache -Dorg.gradle.configuration-cache.read-only=true" >> "$GITHUB_OUTPUT"
             ;;
           *)
             echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
@@ -220,7 +223,7 @@ runs:
 
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -38,6 +38,10 @@ inputs:
   configuration-cache-key:
     description: 'Cache key used to save the project configuration cache.'
     required: false
+  configuration-cache-included-builds:
+    description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
+    required: false
+    default: 'buildSrc,build-logic'
   extra-args:
     description: 'Extra arguments to pass to the Gradle command.'
     required: true
@@ -157,6 +161,26 @@ runs:
         esac
       shell: bash
 
+    - name: Set Configuration Cache Paths
+      id: configuration-cache-paths
+      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      run: |
+        {
+          echo "paths<<EOF"
+          echo ".gradle/configuration-cache"
+
+          IFS=',' read -ra INCLUDED_BUILDS <<< "${{ inputs.configuration-cache-included-builds }}"
+          for included_build in "${INCLUDED_BUILDS[@]}"; do
+            included_build="$(printf '%s' "$included_build" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+            if [ -n "$included_build" ]; then
+              echo "$included_build/build"
+            fi
+          done
+
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Execute Gradle Build
       id: gradle-build
       run: |
@@ -174,7 +198,7 @@ runs:
       if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
       uses: actions/cache/save@v4
       with:
-        path: .gradle/configuration-cache
+        path: ${{ steps.configuration-cache-paths.outputs.paths }}
         key: ${{ inputs.configuration-cache-key }}
 
     - name: Finalize Step

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -187,10 +187,10 @@ runs:
             echo "args=" >> "$GITHUB_OUTPUT"
             ;;
           "on")
-            echo "args=-Dorg.gradle.unsafe.isolated-projects=true" >> "$GITHUB_OUTPUT"
+            echo "args=--isolated-projects" >> "$GITHUB_OUTPUT"
             ;;
           "diagnostics")
-            echo "args=-Dorg.gradle.unsafe.isolated-projects=true -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
+            echo "args=--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
             ;;
           *)
             echo "Unknown project isolation option: ${{ inputs.project-isolation }}"

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -32,7 +32,7 @@ inputs:
     description: 'Mode of execution relative to caching.'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, on, or warn.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, or warn.'
     required: false
     default: 'off'
   project-isolation:
@@ -148,7 +148,7 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.experiment-id }}-${{ inputs.variant }}
 
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache != 'off' || inputs.project-isolation != 'off'
+      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
           echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
@@ -169,6 +169,9 @@ runs:
         case "${{ inputs.configuration-cache }}" in
           "off"|"")
             echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "disabled")
+            echo "args=--no-configuration-cache" >> "$GITHUB_OUTPUT"
             ;;
           "on")
             echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"
@@ -217,7 +220,7 @@ runs:
 
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -255,7 +258,7 @@ runs:
     - name: Execute Gradle Build
       id: gradle-build
       run: |
-        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.project-isolation-args.outputs.args }} \
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} ${{ steps.project-isolation-args.outputs.args }} \
           -Dscan.tag.seed_${{ inputs.variant-prefix }}${{ inputs.variant }} \
           -Dscan.tag.seed-"${{ inputs.mode }}" \
           -Dscan.tag.seed \
@@ -269,7 +272,7 @@ runs:
 
     - name: Prime Configuration Cache
       id: prime-configuration-cache
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off')
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off')
       run: |
         ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} ${{ steps.project-isolation-args.outputs.args }} \
           -Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }} \
@@ -284,7 +287,7 @@ runs:
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Save Configuration Cache
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -228,6 +228,7 @@ runs:
       shell: bash
       env:
         DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}
+        GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Save Configuration Cache

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -42,6 +42,9 @@ inputs:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
     default: 'buildSrc,build-logic,build-logic/*'
+  gradle-encryption-key:
+    description: 'Stable Gradle configuration cache encryption key shared by seed and execution jobs.'
+    required: false
   extra-args:
     description: 'Extra arguments to pass to the Gradle command.'
     required: true
@@ -136,17 +139,20 @@ runs:
       env:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.experiment-id }}-${{ inputs.variant }}
 
-    - name: Disable Gradle Action Init Scripts for Configuration Cache
+    - name: Validate Configuration Cache Encryption Key
       if: inputs.configuration-cache != 'off'
       run: |
-        if [ -n "${GRADLE_USER_HOME:-}" ] && [ -d "$GRADLE_USER_HOME/init.d" ]; then
-          find "$GRADLE_USER_HOME/init.d" -maxdepth 1 -type f -name 'gradle-actions*.init.gradle' -delete
+        if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
+          echo "GRADLE_ENCRYPTION_KEY is required when configuration cache is enabled."
+          exit 1
         fi
       shell: bash
+      env:
+        CHECK_GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
 
     - uses: cdsap/build-process-watcher@v0.6.2
       with:
-        remote_monitoring: 'true'          
+        remote_monitoring: 'true'
         export_to_bigquery: 'true'
 
     - name: Set Configuration Cache Arguments
@@ -176,6 +182,10 @@ runs:
         {
           echo "paths<<EOF"
           echo ".gradle/configuration-cache"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/caches/modules-2"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/caches/[0-9]*"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/caches/jars-*"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/init.d"
 
           IFS=',' read -ra INCLUDED_BUILDS <<< "${{ inputs.configuration-cache-included-builds }}"
           for included_build in "${INCLUDED_BUILDS[@]}"; do
@@ -214,6 +224,7 @@ runs:
       env:
         DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
+        GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Prime Configuration Cache
@@ -229,6 +240,7 @@ runs:
       env:
         DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
+        GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Save Configuration Cache

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -42,6 +42,10 @@ inputs:
   configuration-cache-key:
     description: 'Cache key used to save the project configuration cache.'
     required: false
+  configuration-cache-entry:
+    description: 'Whether to save the seeded configuration cache entry bundle: restore or skip.'
+    required: false
+    default: 'restore'
   configuration-cache-included-builds:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
@@ -199,9 +203,21 @@ runs:
         esac
       shell: bash
 
+    - name: Validate Configuration Cache Entry Mode
+      run: |
+        case "${{ inputs.configuration-cache-entry }}" in
+          "restore"|"skip"|"")
+            ;;
+          *)
+            echo "Unknown configuration cache entry option: ${{ inputs.configuration-cache-entry }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -253,7 +269,7 @@ runs:
 
     - name: Prime Configuration Cache
       id: prime-configuration-cache
-      if: inputs.configuration-cache != 'off' || inputs.project-isolation != 'off'
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off')
       run: |
         ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} ${{ steps.project-isolation-args.outputs.args }} \
           -Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }} \
@@ -268,7 +284,7 @@ runs:
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Save Configuration Cache
-      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -35,6 +35,10 @@ inputs:
     description: 'Gradle configuration cache behavior: off, on, or warn.'
     required: false
     default: 'off'
+  project-isolation:
+    description: 'Gradle Isolated Projects behavior: off, on, or diagnostics.'
+    required: false
+    default: 'off'
   configuration-cache-key:
     description: 'Cache key used to save the project configuration cache.'
     required: false
@@ -140,10 +144,10 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.experiment-id }}-${{ inputs.variant }}
 
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache != 'off'
+      if: inputs.configuration-cache != 'off' || inputs.project-isolation != 'off'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
-          echo "GRADLE_ENCRYPTION_KEY is required when configuration cache is enabled."
+          echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
           exit 1
         fi
       shell: bash
@@ -175,9 +179,29 @@ runs:
         esac
       shell: bash
 
+    - name: Set Project Isolation Arguments
+      id: project-isolation-args
+      run: |
+        case "${{ inputs.project-isolation }}" in
+          "off"|"")
+            echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "on")
+            echo "args=-Dorg.gradle.unsafe.isolated-projects=true" >> "$GITHUB_OUTPUT"
+            ;;
+          "diagnostics")
+            echo "args=-Dorg.gradle.unsafe.isolated-projects=true -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "Unknown project isolation option: ${{ inputs.project-isolation }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -215,7 +239,7 @@ runs:
     - name: Execute Gradle Build
       id: gradle-build
       run: |
-        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} \
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.project-isolation-args.outputs.args }} \
           -Dscan.tag.seed_${{ inputs.variant-prefix }}${{ inputs.variant }} \
           -Dscan.tag.seed-"${{ inputs.mode }}" \
           -Dscan.tag.seed \
@@ -229,9 +253,9 @@ runs:
 
     - name: Prime Configuration Cache
       id: prime-configuration-cache
-      if: inputs.configuration-cache != 'off'
+      if: inputs.configuration-cache != 'off' || inputs.project-isolation != 'off'
       run: |
-        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} \
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} ${{ steps.project-isolation-args.outputs.args }} \
           -Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }} \
           -Dscan.tag."${{ inputs.mode }}" \
           -Dscan.tag.experiment \
@@ -244,7 +268,7 @@ runs:
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
 
     - name: Save Configuration Cache
-      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -184,11 +184,25 @@ runs:
     - name: Execute Gradle Build
       id: gradle-build
       run: |
-        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} \
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} \
           -Dscan.tag.seed_${{ inputs.variant-prefix }}${{ inputs.variant }} \
           -Dscan.tag.seed-"${{ inputs.mode }}" \
           -Dscan.tag.seed \
           -Dscan.tag.seed_${{ inputs.experiment-id }}
+      shell: bash
+      env:
+        DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}
+        CI_URL_CACHE_NODE: ${{ inputs.cache-url }}
+
+    - name: Prime Configuration Cache
+      id: prime-configuration-cache
+      if: inputs.configuration-cache != 'off'
+      run: |
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} \
+          -Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }} \
+          -Dscan.tag."${{ inputs.mode }}" \
+          -Dscan.tag.experiment \
+          -Dscan.tag.${{ inputs.experiment-id }}
       shell: bash
       env:
         DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}

--- a/.github/workflows/runner-seed/action.yaml
+++ b/.github/workflows/runner-seed/action.yaml
@@ -172,7 +172,20 @@ runs:
           IFS=',' read -ra INCLUDED_BUILDS <<< "${{ inputs.configuration-cache-included-builds }}"
           for included_build in "${INCLUDED_BUILDS[@]}"; do
             included_build="$(printf '%s' "$included_build" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-            if [ -n "$included_build" ]; then
+            if [ -z "$included_build" ]; then
+              continue
+            fi
+
+            if [[ "$included_build" == */\* ]]; then
+              parent="${included_build%/*}"
+              if [ -d "$parent" ]; then
+                for child in "$parent"/*; do
+                  if [ -d "$child" ]; then
+                    echo "$child/build"
+                  fi
+                done
+              fi
+            else
               echo "$included_build/build"
             fi
           done

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -34,20 +34,16 @@ inputs:
     description: 'Mode of execution relative to caching'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, disabled, on, warn, or read-only.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, on-no-entry, warn, warn-no-entry, read-only, or read-only-no-entry.'
     required: false
     default: 'off'
   project-isolation:
-    description: 'Gradle Isolated Projects behavior: off, on, or diagnostics.'
+    description: 'Gradle Isolated Projects behavior: off, on, on-no-entry, diagnostics, or diagnostics-no-entry.'
     required: false
     default: 'off'
   configuration-cache-key:
     description: 'Cache key used to restore the seeded project configuration cache.'
     required: false
-  configuration-cache-entry:
-    description: 'Whether to restore the seeded configuration cache entry bundle: restore or skip.'
-    required: false
-    default: 'restore'
   configuration-cache-included-builds:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
@@ -91,8 +87,57 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
+    - name: Set Gradle Feature State
+      id: gradle-feature-state
+      run: |
+        feature_enabled=false
+        entry_mode=skip
+        no_entry=false
+
+        case "${{ inputs.configuration-cache }}" in
+          "off"|"disabled"|"")
+            ;;
+          "on"|"warn"|"read-only")
+            feature_enabled=true
+            entry_mode=restore
+            ;;
+          "on-no-entry"|"warn-no-entry"|"read-only-no-entry")
+            feature_enabled=true
+            no_entry=true
+            ;;
+          *)
+            echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
+            exit 1
+            ;;
+        esac
+
+        case "${{ inputs.project-isolation }}" in
+          "off"|"")
+            ;;
+          "on"|"diagnostics")
+            feature_enabled=true
+            entry_mode=restore
+            ;;
+          "on-no-entry"|"diagnostics-no-entry")
+            feature_enabled=true
+            no_entry=true
+            ;;
+          *)
+            echo "Unknown project isolation option: ${{ inputs.project-isolation }}"
+            exit 1
+            ;;
+        esac
+
+        if [ "$no_entry" = true ]; then
+          entry_mode=skip
+        fi
+
+        echo "feature_enabled=$feature_enabled" >> "$GITHUB_OUTPUT"
+        echo "entry_mode=$entry_mode" >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off'
+      if: steps.gradle-feature-state.outputs.feature_enabled == 'true'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
           echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
@@ -101,18 +146,6 @@ runs:
       shell: bash
       env:
         CHECK_GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
-
-    - name: Validate Configuration Cache Entry Mode
-      run: |
-        case "${{ inputs.configuration-cache-entry }}" in
-          "restore"|"skip"|"")
-            ;;
-          *)
-            echo "Unknown configuration cache entry option: ${{ inputs.configuration-cache-entry }}"
-            exit 1
-            ;;
-        esac
-      shell: bash
 
     - name: Validate Gradle Feature Combination
       run: |
@@ -125,7 +158,7 @@ runs:
 
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: steps.gradle-feature-state.outputs.entry_mode == 'restore' && steps.gradle-feature-state.outputs.feature_enabled == 'true' && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -166,7 +199,7 @@ runs:
         export_to_bigquery: 'true'
 
     - name: Restore Configuration Cache
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: steps.gradle-feature-state.outputs.entry_mode == 'restore' && steps.gradle-feature-state.outputs.feature_enabled == 'true' && inputs.configuration-cache-key != ''
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}
@@ -183,13 +216,13 @@ runs:
           "disabled")
             echo "args=--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false" >> "$GITHUB_OUTPUT"
             ;;
-          "on")
+          "on"|"on-no-entry")
             echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"
             ;;
-          "warn")
+          "warn"|"warn-no-entry")
             echo "args=--configuration-cache --configuration-cache-problems=warn" >> "$GITHUB_OUTPUT"
             ;;
-          "read-only")
+          "read-only"|"read-only-no-entry")
             echo "args=--configuration-cache -Dorg.gradle.configuration-cache.read-only=true" >> "$GITHUB_OUTPUT"
             ;;
           *)
@@ -206,10 +239,10 @@ runs:
           "off"|"")
             echo "args=" >> "$GITHUB_OUTPUT"
             ;;
-          "on")
+          "on"|"on-no-entry")
             echo "args=--isolated-projects" >> "$GITHUB_OUTPUT"
             ;;
-          "diagnostics")
+          "diagnostics"|"diagnostics-no-entry")
             echo "args=--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
             ;;
           *)

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -91,7 +91,20 @@ runs:
           IFS=',' read -ra INCLUDED_BUILDS <<< "${{ inputs.configuration-cache-included-builds }}"
           for included_build in "${INCLUDED_BUILDS[@]}"; do
             included_build="$(printf '%s' "$included_build" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-            if [ -n "$included_build" ]; then
+            if [ -z "$included_build" ]; then
+              continue
+            fi
+
+            if [[ "$included_build" == */\* ]]; then
+              parent="${included_build%/*}"
+              if [ -d "$parent" ]; then
+                for child in "$parent"/*; do
+                  if [ -d "$child" ]; then
+                    echo "$child/build"
+                  fi
+                done
+              fi
+            else
               echo "$included_build/build"
             fi
           done

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -34,7 +34,7 @@ inputs:
     description: 'Mode of execution relative to caching'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, on, or warn.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, or warn.'
     required: false
     default: 'off'
   project-isolation:
@@ -92,7 +92,7 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache != 'off' || inputs.project-isolation != 'off'
+      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
           echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
@@ -116,7 +116,7 @@ runs:
 
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -157,7 +157,7 @@ runs:
         export_to_bigquery: 'true'
 
     - name: Restore Configuration Cache
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}
@@ -170,6 +170,9 @@ runs:
         case "${{ inputs.configuration-cache }}" in
           "off"|"")
             echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "disabled")
+            echo "args=--no-configuration-cache" >> "$GITHUB_OUTPUT"
             ;;
           "on")
             echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -80,6 +80,14 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
+    - name: Disable Gradle Action Init Scripts for Configuration Cache
+      if: inputs.configuration-cache != 'off'
+      run: |
+        if [ -n "${GRADLE_USER_HOME:-}" ] && [ -d "$GRADLE_USER_HOME/init.d" ]; then
+          find "$GRADLE_USER_HOME/init.d" -maxdepth 1 -type f -name 'gradle-actions*.init.gradle' -delete
+        fi
+      shell: bash
+
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
       if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -44,6 +44,9 @@ inputs:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
     default: 'buildSrc,build-logic,build-logic/*'
+  gradle-encryption-key:
+    description: 'Stable Gradle configuration cache encryption key shared by seed and execution jobs.'
+    required: false
   extra-args:
     description: 'Extra arguments to pass to the Gradle command'
     required: true
@@ -80,13 +83,16 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
-    - name: Disable Gradle Action Init Scripts for Configuration Cache
+    - name: Validate Configuration Cache Encryption Key
       if: inputs.configuration-cache != 'off'
       run: |
-        if [ -n "${GRADLE_USER_HOME:-}" ] && [ -d "$GRADLE_USER_HOME/init.d" ]; then
-          find "$GRADLE_USER_HOME/init.d" -maxdepth 1 -type f -name 'gradle-actions*.init.gradle' -delete
+        if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
+          echo "GRADLE_ENCRYPTION_KEY is required when configuration cache is enabled."
+          exit 1
         fi
       shell: bash
+      env:
+        CHECK_GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
 
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
@@ -95,6 +101,10 @@ runs:
         {
           echo "paths<<EOF"
           echo ".gradle/configuration-cache"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/caches/modules-2"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/caches/[0-9]*"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/caches/jars-*"
+          echo "${GRADLE_USER_HOME:-$HOME/.gradle}/init.d"
 
           IFS=',' read -ra INCLUDED_BUILDS <<< "${{ inputs.configuration-cache-included-builds }}"
           for included_build in "${INCLUDED_BUILDS[@]}"; do
@@ -121,6 +131,11 @@ runs:
         } >> "$GITHUB_OUTPUT"
       shell: bash
 
+    - uses: cdsap/build-process-watcher@v0.6.2
+      with:
+        remote_monitoring: 'true'
+        export_to_bigquery: 'true'
+
     - name: Restore Configuration Cache
       if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
       uses: actions/cache/restore@v4
@@ -128,11 +143,6 @@ runs:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}
         key: ${{ inputs.configuration-cache-key }}
         fail-on-cache-miss: false
-
-    - uses: cdsap/build-process-watcher@v0.6.2
-      with:
-        remote_monitoring: 'true'          
-        export_to_bigquery: 'true'
 
     - name: Set Configuration Cache Arguments
       id: configuration-cache-args
@@ -166,4 +176,5 @@ runs:
       env:
         DEVELOCITY_ACCESS_KEY: ${{ inputs.api-key }}
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
+        GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
         CI_URL_CACHE_NODE: ${{ inputs.cache-url }}

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -40,6 +40,10 @@ inputs:
   configuration-cache-key:
     description: 'Cache key used to restore the seeded project configuration cache.'
     required: false
+  configuration-cache-included-builds:
+    description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
+    required: false
+    default: 'buildSrc,build-logic'
   extra-args:
     description: 'Extra arguments to pass to the Gradle command'
     required: true
@@ -76,11 +80,31 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
+    - name: Set Configuration Cache Paths
+      id: configuration-cache-paths
+      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      run: |
+        {
+          echo "paths<<EOF"
+          echo ".gradle/configuration-cache"
+
+          IFS=',' read -ra INCLUDED_BUILDS <<< "${{ inputs.configuration-cache-included-builds }}"
+          for included_build in "${INCLUDED_BUILDS[@]}"; do
+            included_build="$(printf '%s' "$included_build" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+            if [ -n "$included_build" ]; then
+              echo "$included_build/build"
+            fi
+          done
+
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: Restore Configuration Cache
       if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
       uses: actions/cache/restore@v4
       with:
-        path: .gradle/configuration-cache
+        path: ${{ steps.configuration-cache-paths.outputs.paths }}
         key: ${{ inputs.configuration-cache-key }}
         fail-on-cache-miss: false
 

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -176,10 +176,10 @@ runs:
             echo "args=" >> "$GITHUB_OUTPUT"
             ;;
           "on")
-            echo "args=-Dorg.gradle.unsafe.isolated-projects=true" >> "$GITHUB_OUTPUT"
+            echo "args=--isolated-projects" >> "$GITHUB_OUTPUT"
             ;;
           "diagnostics")
-            echo "args=-Dorg.gradle.unsafe.isolated-projects=true -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
+            echo "args=--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
             ;;
           *)
             echo "Unknown project isolation option: ${{ inputs.project-isolation }}"

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -114,6 +114,15 @@ runs:
         esac
       shell: bash
 
+    - name: Validate Gradle Feature Combination
+      run: |
+        if [ "${{ inputs.configuration-cache }}" = "disabled" ] && [ "${{ inputs.project-isolation }}" != "off" ] && [ -n "${{ inputs.project-isolation }}" ]; then
+          echo "configuration-cache=disabled cannot be combined with project-isolation=${{ inputs.project-isolation }}."
+          echo "Gradle requires configuration cache when Isolated Projects is enabled."
+          exit 1
+        fi
+      shell: bash
+
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
       if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
@@ -172,7 +181,7 @@ runs:
             echo "args=" >> "$GITHUB_OUTPUT"
             ;;
           "disabled")
-            echo "args=--no-configuration-cache" >> "$GITHUB_OUTPUT"
+            echo "args=--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false" >> "$GITHUB_OUTPUT"
             ;;
           "on")
             echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -43,7 +43,7 @@ inputs:
   configuration-cache-included-builds:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
-    default: 'buildSrc,build-logic'
+    default: 'buildSrc,build-logic,build-logic/*'
   extra-args:
     description: 'Extra arguments to pass to the Gradle command'
     required: true

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -33,6 +33,13 @@ inputs:
   mode:
     description: 'Mode of execution relative to caching'
     required: true
+  configuration-cache:
+    description: 'Gradle configuration cache behavior: off, on, or warn.'
+    required: false
+    default: 'off'
+  configuration-cache-key:
+    description: 'Cache key used to restore the seeded project configuration cache.'
+    required: false
   extra-args:
     description: 'Extra arguments to pass to the Gradle command'
     required: true
@@ -69,14 +76,43 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB: 'seed'
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
+    - name: Restore Configuration Cache
+      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      uses: actions/cache/restore@v4
+      with:
+        path: .gradle/configuration-cache
+        key: ${{ inputs.configuration-cache-key }}
+        fail-on-cache-miss: false
+
     - uses: cdsap/build-process-watcher@v0.6.2
       with:
         remote_monitoring: 'true'          
         export_to_bigquery: 'true'
+
+    - name: Set Configuration Cache Arguments
+      id: configuration-cache-args
+      run: |
+        case "${{ inputs.configuration-cache }}" in
+          "off"|"")
+            echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "on")
+            echo "args=--configuration-cache" >> "$GITHUB_OUTPUT"
+            ;;
+          "warn")
+            echo "args=--configuration-cache --configuration-cache-problems=warn" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Execute Gradle Build
       id: gradle-build
       run: |
-        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} \
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} \
           -Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }} \
           -Dscan.tag."${{ inputs.mode }}" \
           -Dscan.tag.experiment \

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -34,7 +34,7 @@ inputs:
     description: 'Mode of execution relative to caching'
     required: true
   configuration-cache:
-    description: 'Gradle configuration cache behavior: off, disabled, on, or warn.'
+    description: 'Gradle configuration cache behavior: off, disabled, on, warn, or read-only.'
     required: false
     default: 'off'
   project-isolation:
@@ -92,7 +92,7 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off'
+      if: inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
           echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
@@ -116,7 +116,7 @@ runs:
 
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -157,7 +157,7 @@ runs:
         export_to_bigquery: 'true'
 
     - name: Restore Configuration Cache
-      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache == 'on' || inputs.configuration-cache == 'warn' || inputs.configuration-cache == 'read-only' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}
@@ -179,6 +179,9 @@ runs:
             ;;
           "warn")
             echo "args=--configuration-cache --configuration-cache-problems=warn" >> "$GITHUB_OUTPUT"
+            ;;
+          "read-only")
+            echo "args=--configuration-cache -Dorg.gradle.configuration-cache.read-only=true" >> "$GITHUB_OUTPUT"
             ;;
           *)
             echo "Unknown configuration cache option: ${{ inputs.configuration-cache }}"

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -37,6 +37,10 @@ inputs:
     description: 'Gradle configuration cache behavior: off, on, or warn.'
     required: false
     default: 'off'
+  project-isolation:
+    description: 'Gradle Isolated Projects behavior: off, on, or diagnostics.'
+    required: false
+    default: 'off'
   configuration-cache-key:
     description: 'Cache key used to restore the seeded project configuration cache.'
     required: false
@@ -84,10 +88,10 @@ runs:
         GRADLE_BUILD_ACTION_CACHE_KEY_JOB_INSTANCE: ${{ inputs.execution-number }}-${{ inputs.variant }}
 
     - name: Validate Configuration Cache Encryption Key
-      if: inputs.configuration-cache != 'off'
+      if: inputs.configuration-cache != 'off' || inputs.project-isolation != 'off'
       run: |
         if [ -z "$CHECK_GRADLE_ENCRYPTION_KEY" ]; then
-          echo "GRADLE_ENCRYPTION_KEY is required when configuration cache is enabled."
+          echo "GRADLE_ENCRYPTION_KEY is required when configuration cache or project isolation is enabled."
           exit 1
         fi
       shell: bash
@@ -96,7 +100,7 @@ runs:
 
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -137,7 +141,7 @@ runs:
         export_to_bigquery: 'true'
 
     - name: Restore Configuration Cache
-      if: inputs.configuration-cache != 'off' && inputs.configuration-cache-key != ''
+      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}
@@ -164,10 +168,30 @@ runs:
         esac
       shell: bash
 
+    - name: Set Project Isolation Arguments
+      id: project-isolation-args
+      run: |
+        case "${{ inputs.project-isolation }}" in
+          "off"|"")
+            echo "args=" >> "$GITHUB_OUTPUT"
+            ;;
+          "on")
+            echo "args=-Dorg.gradle.unsafe.isolated-projects=true" >> "$GITHUB_OUTPUT"
+            ;;
+          "diagnostics")
+            echo "args=-Dorg.gradle.unsafe.isolated-projects=true -Dorg.gradle.unsafe.isolated-projects.diagnostics=true" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "Unknown project isolation option: ${{ inputs.project-isolation }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Execute Gradle Build
       id: gradle-build
       run: |
-        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} \
+        ./gradlew ${{ inputs.task }} ${{ inputs.extra-args }} ${{ steps.configuration-cache-args.outputs.args }} ${{ steps.project-isolation-args.outputs.args }} \
           -Dscan.tag.${{ inputs.experiment-id }}_${{ inputs.variant-prefix }}${{ inputs.variant }} \
           -Dscan.tag."${{ inputs.mode }}" \
           -Dscan.tag.experiment \

--- a/.github/workflows/runner/action.yaml
+++ b/.github/workflows/runner/action.yaml
@@ -44,6 +44,10 @@ inputs:
   configuration-cache-key:
     description: 'Cache key used to restore the seeded project configuration cache.'
     required: false
+  configuration-cache-entry:
+    description: 'Whether to restore the seeded configuration cache entry bundle: restore or skip.'
+    required: false
+    default: 'restore'
   configuration-cache-included-builds:
     description: 'Comma-separated included build paths whose build outputs are required by the configuration cache.'
     required: false
@@ -98,9 +102,21 @@ runs:
       env:
         CHECK_GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
 
+    - name: Validate Configuration Cache Entry Mode
+      run: |
+        case "${{ inputs.configuration-cache-entry }}" in
+          "restore"|"skip"|"")
+            ;;
+          *)
+            echo "Unknown configuration cache entry option: ${{ inputs.configuration-cache-entry }}"
+            exit 1
+            ;;
+        esac
+      shell: bash
+
     - name: Set Configuration Cache Paths
       id: configuration-cache-paths
-      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       run: |
         {
           echo "paths<<EOF"
@@ -141,7 +157,7 @@ runs:
         export_to_bigquery: 'true'
 
     - name: Restore Configuration Cache
-      if: (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
+      if: inputs.configuration-cache-entry == 'restore' && (inputs.configuration-cache != 'off' || inputs.project-isolation != 'off') && inputs.configuration-cache-key != ''
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.configuration-cache-paths.outputs.paths }}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This workflow executes Gradle tasks across two specified variants (branches) wit
       - `remote task cache + dependencies cache - transforms cache`: Combines remote task, dependency caching, and excludes transforms.
 
   - `configuration_cache`:
-    - **Description**: Controls Gradle configuration cache usage independently of the selected task/dependency cache mode. In the standard experiment workflow, the seed job saves `.gradle/configuration-cache` plus configured included-build outputs with a variant-specific key and execution jobs restore that entry before running. In the Gradle Profiler workflow, the option is added to the generated scenario so profiler warmups and iterations can reuse the configuration cache in the same checkout.
+    - **Description**: Controls Gradle configuration cache usage independently of the selected task/dependency cache mode. In the standard experiment workflow, the seed job primes `.gradle/configuration-cache` with the same Gradle start parameters used by execution jobs, then saves it plus configured included-build outputs with a variant-specific key. Execution jobs restore that entry before running. In the Gradle Profiler workflow, the option is added to the generated scenario so profiler warmups and iterations can reuse the configuration cache in the same checkout.
     - **Type**: `choice`
     - **Default**: `off`
     - **Options**:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ This workflow executes Gradle tasks across two specified variants (branches) wit
       - `remote task cache + dependencies cache`: Combines remote task caching with dependency caching.
       - `remote task cache - transforms cache`: Caches task outputs remotely, excluding transforms cache.
       - `remote task cache + dependencies cache - transforms cache`: Combines remote task, dependency caching, and excludes transforms.
-      
+
+  - `configuration_cache`:
+    - **Description**: Controls Gradle configuration cache usage independently of the selected task/dependency cache mode. In the standard experiment workflow, the seed job saves `.gradle/configuration-cache` with a variant-specific key and execution jobs restore that entry before running. In the Gradle Profiler workflow, the option is added to the generated scenario so profiler warmups and iterations can reuse the configuration cache in the same checkout.
+    - **Type**: `choice`
+    - **Default**: `off`
+    - **Options**:
+      - `off`: Do not pass configuration-cache arguments.
+      - `on`: Pass `--configuration-cache`.
+      - `warn`: Pass `--configuration-cache --configuration-cache-problems=warn`.
+
   - `os_args`:
     - **Description**: Defines the operating system settings for each variant, specifying which OS image to use during workflow execution. This is useful for testing builds across different environments.
     - **Type**: `string`
@@ -127,6 +136,12 @@ Instead of using agents based on experiment iterations, the Gradle Profiler expe
     - **Description**: Number of iterations for the experiment.
     - **Required**: `false`
     - **Default**: `5`
+  - `configuration_cache`:
+    - **Description**: Controls Gradle configuration cache usage for the generated Gradle Profiler scenario. Use `on` for strict configuration-cache execution, or `warn` while evaluating projects with remaining incompatibilities.
+    - **Type**: `choice`
+    - **Required**: `false`
+    - **Default**: `off`
+    - **Options**: `off`, `on`, `warn`
   - `os_args`:
     - **Description**: Operating system configurations for variants.
     - **Type**: `string`

--- a/README.md
+++ b/README.md
@@ -63,13 +63,17 @@ This workflow executes Gradle tasks across two specified variants (branches) wit
       - `remote task cache + dependencies cache - transforms cache`: Combines remote task, dependency caching, and excludes transforms.
 
   - `configuration_cache`:
-    - **Description**: Controls Gradle configuration cache usage independently of the selected task/dependency cache mode. In the standard experiment workflow, the seed job saves `.gradle/configuration-cache` with a variant-specific key and execution jobs restore that entry before running. In the Gradle Profiler workflow, the option is added to the generated scenario so profiler warmups and iterations can reuse the configuration cache in the same checkout.
+    - **Description**: Controls Gradle configuration cache usage independently of the selected task/dependency cache mode. In the standard experiment workflow, the seed job saves `.gradle/configuration-cache` plus configured included-build outputs with a variant-specific key and execution jobs restore that entry before running. In the Gradle Profiler workflow, the option is added to the generated scenario so profiler warmups and iterations can reuse the configuration cache in the same checkout.
     - **Type**: `choice`
     - **Default**: `off`
     - **Options**:
       - `off`: Do not pass configuration-cache arguments.
       - `on`: Pass `--configuration-cache`.
       - `warn`: Pass `--configuration-cache --configuration-cache-problems=warn`.
+
+  - `configuration_cache_included_builds`:
+    - **Description**: Comma-separated included build paths whose `build` directories are saved and restored with the configuration cache. This is needed when a restored configuration-cache entry references compiled included-build outputs, such as `build-logic/build`.
+    - **Default**: `buildSrc,build-logic`
 
   - `os_args`:
     - **Description**: Defines the operating system settings for each variant, specifying which OS image to use during workflow execution. This is useful for testing builds across different environments.

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ This workflow executes Gradle tasks across two specified variants (branches) wit
     - **Type**: `choice`
     - **Default**: `off`
     - **Options**:
-      - `off`: Do not pass configuration-cache arguments.
+      - `off`: Do not pass configuration-cache arguments; target repository defaults still apply.
+      - `disabled`: Pass `--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false` to force configuration cache off even when the target repository enables Isolated Projects in `gradle.properties`.
       - `on`: Pass `--configuration-cache`.
       - `warn`: Pass `--configuration-cache --configuration-cache-problems=warn`.
+      - `read-only`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true`.
 
   - `configuration_cache_included_builds`:
     - **Description**: Comma-separated included build paths whose `build` directories are saved and restored with the configuration cache. This is needed when a restored configuration-cache entry references compiled included-build outputs, such as `build-logic/build` or `build-logic/convention/build`.
@@ -141,11 +143,11 @@ Instead of using agents based on experiment iterations, the Gradle Profiler expe
     - **Required**: `false`
     - **Default**: `5`
   - `configuration_cache`:
-    - **Description**: Controls Gradle configuration cache usage for the generated Gradle Profiler scenario. Use `on` for strict configuration-cache execution, or `warn` while evaluating projects with remaining incompatibilities.
+    - **Description**: Controls Gradle configuration cache usage for the generated Gradle Profiler scenario. Use `on` for strict configuration-cache execution, `warn` while evaluating projects with remaining incompatibilities, `read-only` to reuse an existing entry without writing a new one, or `disabled` to force configuration cache off even when the target repository enables Isolated Projects.
     - **Type**: `choice`
     - **Required**: `false`
     - **Default**: `off`
-    - **Options**: `off`, `on`, `warn`
+    - **Options**: `off`, `disabled`, `on`, `warn`, `read-only`
   - `os_args`:
     - **Description**: Operating system configurations for variants.
     - **Type**: `string`

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ This workflow executes Gradle tasks across two specified variants (branches) wit
       - `warn`: Pass `--configuration-cache --configuration-cache-problems=warn`.
 
   - `configuration_cache_included_builds`:
-    - **Description**: Comma-separated included build paths whose `build` directories are saved and restored with the configuration cache. This is needed when a restored configuration-cache entry references compiled included-build outputs, such as `build-logic/build`.
-    - **Default**: `buildSrc,build-logic`
+    - **Description**: Comma-separated included build paths whose `build` directories are saved and restored with the configuration cache. This is needed when a restored configuration-cache entry references compiled included-build outputs, such as `build-logic/build` or `build-logic/convention/build`.
+    - **Default**: `buildSrc,build-logic,build-logic/*`
 
   - `os_args`:
     - **Description**: Defines the operating system settings for each variant, specifying which OS image to use during workflow execution. This is useful for testing builds across different environments.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,24 @@ This workflow executes Gradle tasks across two specified variants (branches) wit
     - **Options**:
       - `off`: Do not pass configuration-cache arguments; target repository defaults still apply.
       - `disabled`: Pass `--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false` to force configuration cache off even when the target repository enables Isolated Projects in `gradle.properties`.
-      - `on`: Pass `--configuration-cache`.
-      - `warn`: Pass `--configuration-cache --configuration-cache-problems=warn`.
-      - `read-only`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true`.
+      - `on`: Pass `--configuration-cache` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+      - `on-no-entry`: Pass `--configuration-cache` without saving or restoring the explicit configuration-cache entry bundle.
+      - `warn`: Pass `--configuration-cache --configuration-cache-problems=warn` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+      - `warn-no-entry`: Pass `--configuration-cache --configuration-cache-problems=warn` without saving or restoring the explicit configuration-cache entry bundle.
+      - `read-only`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true` and restore the explicit configuration-cache entry bundle in the standard workflow.
+      - `read-only-no-entry`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true` without restoring the explicit configuration-cache entry bundle.
+    - **Entry behavior**: The explicit configuration-cache entry bundle is shared by configuration cache and Isolated Projects. If either selected feature value ends in `-no-entry`, the standard workflow skips saving and restoring that bundle.
+
+  - `project_isolation`:
+    - **Description**: Controls Gradle Isolated Projects independently of the selected task/dependency cache mode. Values without `-no-entry` save/restore the explicit configuration-cache entry bundle in the standard workflow because Isolated Projects requires configuration cache.
+    - **Type**: `choice`
+    - **Default**: `off`
+    - **Options**:
+      - `off`: Do not pass Isolated Projects arguments; target repository defaults still apply.
+      - `on`: Pass `--isolated-projects` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+      - `on-no-entry`: Pass `--isolated-projects` without saving or restoring the explicit configuration-cache entry bundle.
+      - `diagnostics`: Pass `--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+      - `diagnostics-no-entry`: Pass `--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true` without saving or restoring the explicit configuration-cache entry bundle.
 
   - `configuration_cache_included_builds`:
     - **Description**: Comma-separated included build paths whose `build` directories are saved and restored with the configuration cache. This is needed when a restored configuration-cache entry references compiled included-build outputs, such as `build-logic/build` or `build-logic/convention/build`.
@@ -143,11 +158,11 @@ Instead of using agents based on experiment iterations, the Gradle Profiler expe
     - **Required**: `false`
     - **Default**: `5`
   - `configuration_cache`:
-    - **Description**: Controls Gradle configuration cache usage for the generated Gradle Profiler scenario. Use `on` for strict configuration-cache execution, `warn` while evaluating projects with remaining incompatibilities, `read-only` to reuse an existing entry without writing a new one, or `disabled` to force configuration cache off even when the target repository enables Isolated Projects.
+    - **Description**: Controls Gradle configuration cache usage for the generated Gradle Profiler scenario. Use `on` for strict configuration-cache execution, `warn` while evaluating projects with remaining incompatibilities, `read-only` to reuse an existing entry without writing a new one, or `disabled` to force configuration cache off even when the target repository enables Isolated Projects. `*-no-entry` values are accepted for parity with the standard workflow and pass the same Gradle arguments as their base value.
     - **Type**: `choice`
     - **Required**: `false`
     - **Default**: `off`
-    - **Options**: `off`, `disabled`, `on`, `warn`, `read-only`
+    - **Options**: `off`, `disabled`, `on`, `on-no-entry`, `warn`, `warn-no-entry`, `read-only`, `read-only-no-entry`
   - `os_args`:
     - **Description**: Operating system configurations for variants.
     - **Type**: `string`

--- a/docs/actions-inputs.md
+++ b/docs/actions-inputs.md
@@ -48,7 +48,7 @@ This section details the inputs for the primary dispatchable workflows: `experim
     - `'off'`: Do not pass configuration-cache arguments.
     - `'on'`: Pass `--configuration-cache`.
     - `'warn'`: Pass `--configuration-cache --configuration-cache-problems=warn`.
-  - Reuse behavior: `experiment.yaml` saves `.gradle/configuration-cache` from each seed job and restores the matching variant entry in execution jobs. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
+  - Reuse behavior: `experiment.yaml` primes `.gradle/configuration-cache` in each seed job with the same Gradle start parameters used by execution jobs, then restores the matching variant entry in execution jobs. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
 - **`configuration_cache_included_builds`**:
   - Description: Comma-separated included build paths whose build output directories must be saved and restored with the configuration cache.
   - `experiment.yaml`: Required: `false`. Default: `"buildSrc,build-logic,build-logic/*"`.

--- a/docs/actions-inputs.md
+++ b/docs/actions-inputs.md
@@ -51,8 +51,8 @@ This section details the inputs for the primary dispatchable workflows: `experim
   - Reuse behavior: `experiment.yaml` saves `.gradle/configuration-cache` from each seed job and restores the matching variant entry in execution jobs. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
 - **`configuration_cache_included_builds`**:
   - Description: Comma-separated included build paths whose build output directories must be saved and restored with the configuration cache.
-  - `experiment.yaml`: Required: `false`. Default: `"buildSrc,build-logic"`.
-  - Reuse behavior: Each listed path contributes its `build` directory, for example `build-logic` adds `build-logic/build`. This preserves included-build classpath outputs referenced by restored configuration-cache entries.
+  - `experiment.yaml`: Required: `false`. Default: `"buildSrc,build-logic,build-logic/*"`.
+  - Reuse behavior: Each listed path contributes its `build` directory, for example `build-logic` adds `build-logic/build` and `build-logic/*` adds one-level nested outputs such as `build-logic/convention/build`. This preserves included-build classpath outputs referenced by restored configuration-cache entries.
 
 **Inputs Specific to `experiment.yaml`:**
 
@@ -197,7 +197,7 @@ This section lists the seed-action inputs that differ from or extend the standar
 - **`configuration-cache-included-builds`**:
   - Description: Comma-separated included build paths whose `build` directories are saved with the configuration cache.
   - Required: `false`.
-  - Default: `buildSrc,build-logic`.
+  - Default: `buildSrc,build-logic,build-logic/*`.
 - **`cache-exclude-script`**:
   - Description: Optional script content for excluding specific Gradle User Home cache entries.
   - Required: `false`.
@@ -248,7 +248,7 @@ This section details inputs for the reusable `runner/action.yaml` workflow, whic
 - **`configuration-cache-included-builds`**:
   - Description: Comma-separated included build paths whose `build` directories are restored with the configuration cache.
   - Required: `false`.
-  - Default: `buildSrc,build-logic`.
+  - Default: `buildSrc,build-logic,build-logic/*`.
 - **`extra-args`**:
   - Description: Any additional arguments to pass to the Gradle command.
   - Required: `true`.

--- a/docs/actions-inputs.md
+++ b/docs/actions-inputs.md
@@ -47,11 +47,24 @@ This section details the inputs for the primary dispatchable workflows: `experim
   - Options:
     - `'off'`: Do not pass configuration-cache arguments; target repository defaults still apply.
     - `'disabled'`: Pass `--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false` to force configuration cache off even when the target repository enables Isolated Projects in `gradle.properties`.
-    - `'on'`: Pass `--configuration-cache`.
-    - `'warn'`: Pass `--configuration-cache --configuration-cache-problems=warn`.
-    - `'read-only'`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true`.
+    - `'on'`: Pass `--configuration-cache` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+    - `'on-no-entry'`: Pass `--configuration-cache` without saving or restoring the explicit configuration-cache entry bundle.
+    - `'warn'`: Pass `--configuration-cache --configuration-cache-problems=warn` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+    - `'warn-no-entry'`: Pass `--configuration-cache --configuration-cache-problems=warn` without saving or restoring the explicit configuration-cache entry bundle.
+    - `'read-only'`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true` and restore the explicit configuration-cache entry bundle in the standard workflow.
+    - `'read-only-no-entry'`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true` without restoring the explicit configuration-cache entry bundle.
   - Compatibility: `'disabled'` cannot be combined with `project_isolation` values other than `'off'`, because Gradle requires configuration cache when Isolated Projects is enabled.
-  - Reuse behavior: `experiment.yaml` primes `.gradle/configuration-cache` in each seed job with the same Gradle start parameters used by execution jobs, then restores the matching variant entry in execution jobs. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
+  - Reuse behavior: `experiment.yaml` primes `.gradle/configuration-cache` in each seed job with the same Gradle start parameters used by execution jobs, then restores the matching variant entry in execution jobs. If either `configuration_cache` or `project_isolation` ends in `-no-entry`, the standard workflow skips saving and restoring that shared bundle. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
+- **`project_isolation`**:
+  - Description: Controls Gradle Isolated Projects independently of the selected task/dependency cache mode. Values without `-no-entry` save/restore the explicit configuration-cache entry bundle in the standard workflow because Isolated Projects requires configuration cache.
+  - `experiment.yaml`: Required: `true`. Default: `'off'`.
+  - `experiment-with-gradle-profiler.yaml`: Required: `false`. Default: `'off'`.
+  - Options:
+    - `'off'`: Do not pass Isolated Projects arguments; target repository defaults still apply.
+    - `'on'`: Pass `--isolated-projects` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+    - `'on-no-entry'`: Pass `--isolated-projects` without saving or restoring the explicit configuration-cache entry bundle.
+    - `'diagnostics'`: Pass `--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true` and save/restore the explicit configuration-cache entry bundle in the standard workflow.
+    - `'diagnostics-no-entry'`: Pass `--isolated-projects -Dorg.gradle.unsafe.isolated-projects.diagnostics=true` without saving or restoring the explicit configuration-cache entry bundle.
 - **`configuration_cache_included_builds`**:
   - Description: Comma-separated included build paths whose build output directories must be saved and restored with the configuration cache.
   - `experiment.yaml`: Required: `false`. Default: `"buildSrc,build-logic,build-logic/*"`.
@@ -191,7 +204,7 @@ This section describes the inputs for the reusable `report/action.yaml` workflow
 This section lists the seed-action inputs that differ from or extend the standard runner. Other runner inputs such as `task`, `variant`, `repository`, `jdk_version`, `jdk_vendor`, `mode`, `extra-args`, and `cache-url` follow the same meaning as `runner/action.yaml`.
 
 - **`configuration-cache`**:
-  - Description: Gradle configuration cache behavior for the seed run (`off`, `disabled`, `on`, `warn`, or `read-only`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
+  - Description: Gradle configuration cache behavior for the seed run (`off`, `disabled`, `on`, `on-no-entry`, `warn`, `warn-no-entry`, `read-only`, or `read-only-no-entry`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
   - Required: `false`.
   - Default: `off`.
 - **`configuration-cache-key`**:
@@ -242,7 +255,7 @@ This section details inputs for the reusable `runner/action.yaml` workflow, whic
   - Description: Specifies the caching mode for this run (e.g., `no caching`, `local task cache`).
   - Required: `true`.
 - **`configuration-cache`**:
-  - Description: Gradle configuration cache behavior for the run (`off`, `disabled`, `on`, `warn`, or `read-only`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
+  - Description: Gradle configuration cache behavior for the run (`off`, `disabled`, `on`, `on-no-entry`, `warn`, `warn-no-entry`, `read-only`, or `read-only-no-entry`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
   - Required: `false`.
   - Default: `off`.
 - **`configuration-cache-key`**:
@@ -308,7 +321,7 @@ This section describes inputs for the reusable `runner-gradle-profiler/action.ya
   - Description: Any additional arguments to pass to the Gradle command.
   - Required: `true`.
 - **`configuration-cache`**:
-  - Description: Gradle configuration cache behavior for the generated scenario (`off`, `disabled`, `on`, `warn`, or `read-only`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
+  - Description: Gradle configuration cache behavior for the generated scenario (`off`, `disabled`, `on`, `on-no-entry`, `warn`, `warn-no-entry`, `read-only`, or `read-only-no-entry`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
   - Required: `false`.
   - Default: `off`.
 - **`cache-url`**:

--- a/docs/actions-inputs.md
+++ b/docs/actions-inputs.md
@@ -49,6 +49,10 @@ This section details the inputs for the primary dispatchable workflows: `experim
     - `'on'`: Pass `--configuration-cache`.
     - `'warn'`: Pass `--configuration-cache --configuration-cache-problems=warn`.
   - Reuse behavior: `experiment.yaml` saves `.gradle/configuration-cache` from each seed job and restores the matching variant entry in execution jobs. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
+- **`configuration_cache_included_builds`**:
+  - Description: Comma-separated included build paths whose build output directories must be saved and restored with the configuration cache.
+  - `experiment.yaml`: Required: `false`. Default: `"buildSrc,build-logic"`.
+  - Reuse behavior: Each listed path contributes its `build` directory, for example `build-logic` adds `build-logic/build`. This preserves included-build classpath outputs referenced by restored configuration-cache entries.
 
 **Inputs Specific to `experiment.yaml`:**
 
@@ -190,6 +194,10 @@ This section lists the seed-action inputs that differ from or extend the standar
 - **`configuration-cache-key`**:
   - Description: Variant-specific key used to save `.gradle/configuration-cache` for execution jobs.
   - Required: `false`.
+- **`configuration-cache-included-builds`**:
+  - Description: Comma-separated included build paths whose `build` directories are saved with the configuration cache.
+  - Required: `false`.
+  - Default: `buildSrc,build-logic`.
 - **`cache-exclude-script`**:
   - Description: Optional script content for excluding specific Gradle User Home cache entries.
   - Required: `false`.
@@ -237,6 +245,10 @@ This section details inputs for the reusable `runner/action.yaml` workflow, whic
 - **`configuration-cache-key`**:
   - Description: Variant-specific key used to restore the configuration cache saved by the seed job.
   - Required: `false`.
+- **`configuration-cache-included-builds`**:
+  - Description: Comma-separated included build paths whose `build` directories are restored with the configuration cache.
+  - Required: `false`.
+  - Default: `buildSrc,build-logic`.
 - **`extra-args`**:
   - Description: Any additional arguments to pass to the Gradle command.
   - Required: `true`.

--- a/docs/actions-inputs.md
+++ b/docs/actions-inputs.md
@@ -45,9 +45,12 @@ This section details the inputs for the primary dispatchable workflows: `experim
   - `experiment.yaml`: Required: `true`. Default: `'off'`.
   - `experiment-with-gradle-profiler.yaml`: Required: `false`. Default: `'off'`.
   - Options:
-    - `'off'`: Do not pass configuration-cache arguments.
+    - `'off'`: Do not pass configuration-cache arguments; target repository defaults still apply.
+    - `'disabled'`: Pass `--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false` to force configuration cache off even when the target repository enables Isolated Projects in `gradle.properties`.
     - `'on'`: Pass `--configuration-cache`.
     - `'warn'`: Pass `--configuration-cache --configuration-cache-problems=warn`.
+    - `'read-only'`: Pass `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true`.
+  - Compatibility: `'disabled'` cannot be combined with `project_isolation` values other than `'off'`, because Gradle requires configuration cache when Isolated Projects is enabled.
   - Reuse behavior: `experiment.yaml` primes `.gradle/configuration-cache` in each seed job with the same Gradle start parameters used by execution jobs, then restores the matching variant entry in execution jobs. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
 - **`configuration_cache_included_builds`**:
   - Description: Comma-separated included build paths whose build output directories must be saved and restored with the configuration cache.
@@ -188,7 +191,7 @@ This section describes the inputs for the reusable `report/action.yaml` workflow
 This section lists the seed-action inputs that differ from or extend the standard runner. Other runner inputs such as `task`, `variant`, `repository`, `jdk_version`, `jdk_vendor`, `mode`, `extra-args`, and `cache-url` follow the same meaning as `runner/action.yaml`.
 
 - **`configuration-cache`**:
-  - Description: Gradle configuration cache behavior for the seed run (`off`, `on`, or `warn`).
+  - Description: Gradle configuration cache behavior for the seed run (`off`, `disabled`, `on`, `warn`, or `read-only`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
   - Required: `false`.
   - Default: `off`.
 - **`configuration-cache-key`**:
@@ -239,7 +242,7 @@ This section details inputs for the reusable `runner/action.yaml` workflow, whic
   - Description: Specifies the caching mode for this run (e.g., `no caching`, `local task cache`).
   - Required: `true`.
 - **`configuration-cache`**:
-  - Description: Gradle configuration cache behavior for the run (`off`, `on`, or `warn`).
+  - Description: Gradle configuration cache behavior for the run (`off`, `disabled`, `on`, `warn`, or `read-only`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
   - Required: `false`.
   - Default: `off`.
 - **`configuration-cache-key`**:
@@ -305,7 +308,7 @@ This section describes inputs for the reusable `runner-gradle-profiler/action.ya
   - Description: Any additional arguments to pass to the Gradle command.
   - Required: `true`.
 - **`configuration-cache`**:
-  - Description: Gradle configuration cache behavior for the generated scenario (`off`, `on`, or `warn`).
+  - Description: Gradle configuration cache behavior for the generated scenario (`off`, `disabled`, `on`, `warn`, or `read-only`). `disabled` forces configuration cache off and disables repo-level Isolated Projects with `-Dorg.gradle.unsafe.isolated-projects=false`.
   - Required: `false`.
   - Default: `off`.
 - **`cache-url`**:

--- a/docs/actions-inputs.md
+++ b/docs/actions-inputs.md
@@ -40,6 +40,15 @@ This section details the inputs for the primary dispatchable workflows: `experim
   - Description: A JSON string to configure report generation. See the "Extra Report Arguments (`extra_report_args`)" section under "JSON Format Examples" for details on the keys.
   - `experiment.yaml`: Required: `true`. Default: `"{deploy_results:'false',experiment_title:'', open_ai_request:'true', report_enabled:'true',tasktype_report:'true',taskpath_report:'true',kotlin_build_report:'false',process_report:'false',resource_usage_report:'true',gc_report:'false',only_cacheable_outcome:'false',threshold_task_duration:'1000'}"`.
   - `experiment-with-gradle-profiler.yaml`: Required: `false`. Default: `"{deploy_results:'false',experiment_title:'',open_ai_request:'true',report_enabled:'true',tasktype_report:'true',taskpath_report:'true',kotlin_build_report:'false',process_report:'false',resource_usage_report:'true',gc_report:'false',only_cacheable_outcome:'false',threshold_task_duration:'1000'}"`.
+- **`configuration_cache`**:
+  - Description: Controls Gradle configuration cache usage independently of the selected task/dependency cache mode.
+  - `experiment.yaml`: Required: `true`. Default: `'off'`.
+  - `experiment-with-gradle-profiler.yaml`: Required: `false`. Default: `'off'`.
+  - Options:
+    - `'off'`: Do not pass configuration-cache arguments.
+    - `'on'`: Pass `--configuration-cache`.
+    - `'warn'`: Pass `--configuration-cache --configuration-cache-problems=warn`.
+  - Reuse behavior: `experiment.yaml` saves `.gradle/configuration-cache` from each seed job and restores the matching variant entry in execution jobs. `experiment-with-gradle-profiler.yaml` adds the selected arguments to the generated scenario so profiler warmups and iterations can reuse configuration in the same checkout.
 
 **Inputs Specific to `experiment.yaml`:**
 
@@ -64,6 +73,7 @@ This section details the inputs for the primary dispatchable workflows: `experim
     - `'remote task cache + dependencies cache'`
     - `'remote task cache - transforms cache'`
     - `'remote task cache + dependencies cache - transforms cache'`
+    - `'dependencies cache - javaCompile cache'`
 
 **Inputs Specific to `experiment-with-gradle-profiler.yaml`:**
 
@@ -169,6 +179,21 @@ This section describes the inputs for the reusable `report/action.yaml` workflow
   - Required: `true` (conditionally, if deploying).
   - Default: `""`.
 
+## Reusable Workflow: Seed Runner Action (`.github/workflows/runner-seed/action.yaml`)
+
+This section lists the seed-action inputs that differ from or extend the standard runner. Other runner inputs such as `task`, `variant`, `repository`, `jdk_version`, `jdk_vendor`, `mode`, `extra-args`, and `cache-url` follow the same meaning as `runner/action.yaml`.
+
+- **`configuration-cache`**:
+  - Description: Gradle configuration cache behavior for the seed run (`off`, `on`, or `warn`).
+  - Required: `false`.
+  - Default: `off`.
+- **`configuration-cache-key`**:
+  - Description: Variant-specific key used to save `.gradle/configuration-cache` for execution jobs.
+  - Required: `false`.
+- **`cache-exclude-script`**:
+  - Description: Optional script content for excluding specific Gradle User Home cache entries.
+  - Required: `false`.
+
 ## Reusable Workflow: Runner Action (`.github/workflows/runner/action.yaml`)
 
 This section details inputs for the reusable `runner/action.yaml` workflow, which executes a single Gradle build iteration for the standard experiment.
@@ -205,6 +230,13 @@ This section details inputs for the reusable `runner/action.yaml` workflow, whic
 - **`mode`**:
   - Description: Specifies the caching mode for this run (e.g., `no caching`, `local task cache`).
   - Required: `true`.
+- **`configuration-cache`**:
+  - Description: Gradle configuration cache behavior for the run (`off`, `on`, or `warn`).
+  - Required: `false`.
+  - Default: `off`.
+- **`configuration-cache-key`**:
+  - Description: Variant-specific key used to restore the configuration cache saved by the seed job.
+  - Required: `false`.
 - **`extra-args`**:
   - Description: Any additional arguments to pass to the Gradle command.
   - Required: `true`.
@@ -260,6 +292,10 @@ This section describes inputs for the reusable `runner-gradle-profiler/action.ya
 - **`extra-args`**:
   - Description: Any additional arguments to pass to the Gradle command.
   - Required: `true`.
+- **`configuration-cache`**:
+  - Description: Gradle configuration cache behavior for the generated scenario (`off`, `on`, or `warn`).
+  - Required: `false`.
+  - Default: `off`.
 - **`cache-url`**:
   - Description: URL of the remote build cache node, if used.
   - Required: `true`.


### PR DESCRIPTION
## Summary

Experiment workflows can now run Gradle with configuration cache enabled and reuse the seeded configuration state across execution jobs. The seed job primes the configuration cache, saves the Gradle user-home inputs that Gradle fingerprints, and stores included-build outputs with the project cache entry. Execution jobs restore that complete set before invoking Gradle.

The workflow exposes `off`, `disabled`, `on`, `warn`, and `read-only` modes for configuration-cache runs, and wires the same option into Gradle Profiler scenarios. `off` leaves Gradle's default behavior alone. `disabled` explicitly passes `--no-configuration-cache`. `read-only` passes `--configuration-cache -Dorg.gradle.configuration-cache.read-only=true`, so Gradle can reuse an existing entry but will not write a new one on a miss.

This adds a separate `project_isolation` input with `off`, `on`, and `diagnostics` modes. Project isolation uses the same restored configuration-cache inputs because Gradle enables configuration-cache infrastructure when Isolated Projects is enabled; the Gradle 9.7 path uses `--isolated-projects`, with diagnostics adding `-Dorg.gradle.unsafe.isolated-projects.diagnostics=true`.

This also adds `configuration_cache_entry` with `restore` and `skip` modes. `restore` keeps the seeded CC-entry reuse path. `skip` still builds with `--configuration-cache` or `--isolated-projects`, but intentionally skips the explicit configuration-cache entry path setup, restore, prime, and save steps.

## Validation

- Parsed the touched workflow YAML files locally.
- Ran `git diff --check`.
- Created `GRADLE_ENCRYPTION_KEY` for `cdsap/Telltale`.
- Dispatched `experiment.yaml` on this branch: https://github.com/cdsap/Telltale/actions/runs/31440340933
- The run passed, and all 10 execution jobs printed `Reusing configuration cache.`
- Dispatched `experiment-with-gradle-profiler.yaml` on this branch: https://github.com/cdsap/Telltale/actions/runs/31443035558
- The profiler run passed, and both profiler variants reused configuration cache after the first invocation.
- Dispatched a `project_isolation=on` smoke on this branch: https://github.com/cdsap/Telltale/actions/runs/31515873565
- The smoke verified the new input reaches Gradle as `--isolated-projects`, then failed in the target experiment build because `:core:checkout` is not Isolated Projects compatible (`Project ':core:checkout' cannot access task dependencies directly`).
- Dispatched a `configuration_cache=on` plus `configuration_cache_entry=skip` smoke on this branch: https://github.com/cdsap/Telltale/actions/runs/31522487020
- The no-entry smoke passed. Logs show Set Configuration Cache Paths, Restore Configuration Cache, Prime Configuration Cache, and Save Configuration Cache were skipped; execution jobs still invoked Gradle with `--configuration-cache` and calculated the task graph because no cached configuration entry was provided.
- Dispatched a `configuration_cache=disabled` smoke on this branch: https://github.com/cdsap/Telltale/actions/runs/31647317157
- The disabled-mode smoke passed. Logs show seed and execution jobs invoked Gradle with `--no-configuration-cache`, and the explicit configuration-cache entry path setup, restore, prime, and save steps were skipped.
- Dispatched a `configuration_cache=read-only` smoke on this branch: https://github.com/cdsap/Telltale/actions/runs/31648564651
- The read-only smoke is currently queued in GitHub Actions; local YAML parsing and diff checks passed before dispatch.
